### PR TITLE
Fix for " is not a valid attribute name" related to "renormalize = true"

### DIFF
--- a/gitcrypt
+++ b/gitcrypt
@@ -95,7 +95,7 @@ init_config() {
 
 	echo "$pattern filter=encrypt diff=encrypt" >> $attrs
 	echo "[merge]" >> $attrs
-	echo "    renormalize = true" >> $attrs
+	echo "    renormalize=true" >> $attrs
 
 	# Encryption
 	git config gitcrypt.salt "$SALT"


### PR DESCRIPTION
The previous command "renormalize = true" caused the following to be 
dumped on the console with any gitcrypt enabled repo:
    is not a valid attribute name: .git/info/attributes:3
