### PR TITLE
Fix an issue with tr on OS X

### DIFF
--- a/gitcrypt
+++ b/gitcrypt
@@ -37,7 +37,7 @@ init_config() {
 					read PASS
 					;;
 				*)
-					PASS=$(cat /dev/urandom | tr -dc '!@#$%^&*()_A-Z-a-z-0-9' | head -c32)
+					PASS=$(cat /dev/urandom | LC_ALL="C" tr -dc '!@#$%^&*()_A-Z-a-z-0-9' | head -c32)
 					;;
 			esac
 		done


### PR DESCRIPTION
The version of tr that ships with OS X can't handle certain binary
inputs if the locale is set to a certain value. This sets the locale
to C.
