### PR TITLE
gitcrypt configuration now accepts whitespace separated list of patterns

### DIFF
--- a/gitcrypt
+++ b/gitcrypt
@@ -88,12 +88,14 @@ init_config() {
 			;;
 	esac
 
-	local pattern
+	local patterns
 	echo -n "What files do you want encrypted? [*] "
-	read pattern
-	[ -z "$pattern" ] && pattern="*"
+	read patterns
+	[ -z "$patterns" ] && patterns="*"
 
-	echo "$pattern filter=encrypt diff=encrypt" >> $attrs
+	for pattern in $patterns; do
+		echo "$pattern filter=encrypt diff=encrypt" >> $attrs
+	done
 	echo "[merge]" >> $attrs
 	echo "    renormalize=true" >> $attrs
 


### PR DESCRIPTION
Pretty much what it says on the tin. When configuring encryption via `gitcrypt init`, you can now give a whitespace-separated list of patterns, which will be echoed to the attributes file, one per line.

```
(...)
Do you want to use .git/info/attributes? [Y/n] n
What files do you want encrypted? [*] /keys/* /credentials/*
kandinski@desire:~/test$ less .gitattributes 
kandinski@desire:~/test$ cat .gitattributes
/keys/* filter=encrypt diff=encrypt
/credentials/* filter=encrypt diff=encrypt
[merge]
    renormalize=true
kandinski@desire:~/test$ 
```
