### PR TITLE
Remove spaces in "renormalize" line

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To encrypt all the files in the repo:
 
     * filter=encrypt diff=encrypt
     [merge]
-        renormalize = true
+        renormalize=true
 
 To encrypt only one file, you could do this:
 


### PR DESCRIPTION
In the manual configuration instructions, the spaces in the "renormalize = true" line around the "=" sign need to be removed. With those spaces, "git reset --hard head" produces the following error: " is not a valid attribute name: .git/info/attributes:3" (note the leading space).

Related: #11
