### PR TITLE
Don't echo password to terminal

### DIFF
--- a/gitcrypt
+++ b/gitcrypt
@@ -47,7 +47,8 @@ init_config() {
 			case "$answer" in
 				n*|N*)
 					echo -n "Enter your passphrase: "
-					read PASS
+					read -s PASS
+					echo
 					;;
 				*)
 					PASS=$(cat /dev/urandom | LC_ALL="C" tr -dc '!@#$%^&*()_A-Z-a-z-0-9' | head -c32)
@@ -69,7 +70,7 @@ init_config() {
 
 		echo -e "\nThis configuration will be stored:\n"
 		echo "salt:   $SALT"
-		echo "pass:   $PASS"
+		echo "pass:   *****************"
 		echo "cipher: $CIPHER"
 		echo -e -n "\nDoes this look right? [Y/n] "
 		read answer


### PR DESCRIPTION
I'd find it useful to be able to use this in a context where someone may be looking over my shoulder - in that case I wouldn't want the password printed on the terminal.  I can see cases though where it's convenient to have the password echoed (such as, to verify that you entered it correctly) - maybe this behavior should be optional?
